### PR TITLE
Updates for Dropwizard 3.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <dropwizard.version>2.0.9</dropwizard.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <dropwizard.version>3.0.1</dropwizard.version>
         <!-- Flaky test setting, re-run more 2 times in case of a failure -->
         <surefire.rerunFailingTestsCount>2</surefire.rerunFailingTestsCount>
     </properties>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
+            <version>1.18.28</version>
             <scope>provided</scope>
         </dependency>
 
@@ -90,14 +90,14 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.2</version>
+            <version>5.9.3</version>
             <scope>test</scope>
         </dependency>
         <!-- AssertJ to have proper assertions -->
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.16.1</version>
+            <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -107,13 +107,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M4</version>
+                <version>3.1.2</version>
             </plugin>
             <!-- Versioning the JAR -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -126,7 +126,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
+                <version>0.8.10</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -163,7 +163,7 @@
             <!-- Release plugin to push package to repository -->
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>3.0.1</version>
                 <configuration>
                     <useReleaseProfile>false</useReleaseProfile>
                     <releaseProfiles>release</releaseProfiles>
@@ -176,7 +176,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -189,7 +189,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -202,7 +202,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -222,7 +222,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.0</version>
+                        <version>3.3.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -235,7 +235,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.1.1</version>
+                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/src/main/java/com/github/mtakaki/dropwizard/admin/AdminResourceBundle.java
+++ b/src/main/java/com/github/mtakaki/dropwizard/admin/AdminResourceBundle.java
@@ -1,16 +1,16 @@
 package com.github.mtakaki.dropwizard.admin;
 
+import io.dropwizard.core.ConfiguredBundle;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 import org.glassfish.jersey.servlet.ServletContainer;
 
 import com.codahale.metrics.jersey2.InstrumentedResourceMethodApplicationListener;
 
-import io.dropwizard.Bundle;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.setup.JerseyContainerHolder;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
-import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Bootstrap;
+import io.dropwizard.core.setup.Environment;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
  * @author mtakaki
  */
 @RequiredArgsConstructor
-public class AdminResourceBundle implements Bundle {
+public class AdminResourceBundle<T> implements ConfiguredBundle<T> {
     private final String basePath;
     @Getter
     private JerseyEnvironment jerseyEnvironment;
@@ -38,7 +38,7 @@ public class AdminResourceBundle implements Bundle {
     }
 
     @Override
-    public void run(final Environment environment) {
+    public void run(final T config, final Environment environment) {
         this.jerseyEnvironment = this.setupAdminEnvironment(environment);
     }
 

--- a/src/main/java/com/github/mtakaki/dropwizard/admin/DropwizardAdminResourceConfig.java
+++ b/src/main/java/com/github/mtakaki/dropwizard/admin/DropwizardAdminResourceConfig.java
@@ -4,9 +4,16 @@ import com.codahale.metrics.MetricRegistry;
 
 import io.dropwizard.jersey.DropwizardResourceConfig;
 
+/**
+ * Configuration for Jersey servlet hosting the admin endpoint
+ */
 public class DropwizardAdminResourceConfig extends DropwizardResourceConfig {
     private static final String NEWLINE = String.format("%n");
 
+    /**
+     * Constructor
+     * @param metricRegistry Dropwizard metrics registry
+     */
     public DropwizardAdminResourceConfig(final MetricRegistry metricRegistry) {
         super(metricRegistry);
     }

--- a/src/test/java/com/github/mtakaki/dropwizard/admin/AdminResourceBundleIntegrationTest.java
+++ b/src/test/java/com/github/mtakaki/dropwizard/admin/AdminResourceBundleIntegrationTest.java
@@ -11,10 +11,10 @@ import javax.ws.rs.core.MediaType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.dropwizard.Application;
-import io.dropwizard.Configuration;
-import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.Application;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.Bootstrap;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.testing.DropwizardTestSupport;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
@@ -46,7 +46,7 @@ public class AdminResourceBundleIntegrationTest {
     }
 
     public static class TestApplication extends Application<TestConfiguration> {
-        private final AdminResourceBundle adminResource = new AdminResourceBundle();
+        private final AdminResourceBundle<TestConfiguration> adminResource = new AdminResourceBundle<>();
 
         @Override
         public void initialize(final Bootstrap<TestConfiguration> bootstrap) {


### PR DESCRIPTION
Like the title says. I also updated several of the dependencies in pom.xml. (Except the Maven GPG plugin. It jumped several major versions and I didn't really want to fight with that. Especially since I have no good way to test it.)

For https://github.com/mtakaki/dropwizard-admin-resource/issues/4

The idea is that when this is merged, the 4.0.x updates would be built on top of this.